### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
   A Model Context Protocol (MCP) server for generating and editing images using the OpenAI <code>gpt-image-1</code> model.
 </p>
 
+<a href="https://glama.ai/mcp/servers/@CLOUDWERX-DEV/gpt-image-1-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CLOUDWERX-DEV/gpt-image-1-mcp/badge" alt="GPT Image 1 MCP server" />
+</a>
+
 <p align="center">
   <img src="https://img.shields.io/badge/OpenAI-GPT--Image--1-6E46AE" alt="OpenAI GPT-Image-1">
   <img src="https://img.shields.io/badge/MCP-Compatible-00A3E0" alt="MCP Compatible">


### PR DESCRIPTION
This PR adds a badge for the [GPT Image 1 MCP](https://glama.ai/mcp/servers/@CLOUDWERX-DEV/gpt-image-1-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CLOUDWERX-DEV/gpt-image-1-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CLOUDWERX-DEV/gpt-image-1-mcp/badge" alt="GPT Image 1 MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.